### PR TITLE
Fix Ruby 2.5.1 bump

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,7 +295,7 @@ DEPENDENCIES
   web-console
 
 RUBY VERSION
-   ruby 2.4.3p205
+   ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.1
+   1.16.4

--- a/script/cibuild
+++ b/script/cibuild
@@ -7,8 +7,19 @@ cd "$(dirname "$0")/.."
 
 set +e
 
+RUBY_VERSION="$(cat .ruby-version)"
+echo "==> Checking for Ruby $RUBY_VERSION in Gemfile.lock..."
+if grep -o "ruby $RUBY_VERSION.*" Gemfile.lock
+then
+  RUBY_GREP_EXIT="0"
+else
+  echo "Could not find $RUBY_VERSION in Gemfile.lock!"
+  RUBY_GREP_EXIT="1"
+fi
+
 bundle exec rake test
 RAKE_EXIT="$?"
+
 bundle exec rubocop
 RUBOCOP_EXIT="$?"
-[[ "$RAKE_EXIT" == 0 && "$RUBOCOP_EXIT" == 0 ]]
+[[ "$RUBY_GREP_EXIT" == 0 && "$RAKE_EXIT" == 0 && "$RUBOCOP_EXIT" == 0 ]]


### PR DESCRIPTION
I always forget you also need to run `bundle install` for Heroku apps so the Gemfile.lock is updated. Add a `script/cibuild` check to make sure no-one makes this mistake in future.