### PR TITLE
Tweak French translation

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,6 +4,6 @@ module ApplicationHelper
   end
 
   def language_name(locale)
-    Rails.configuration.Languages[locale.to_s]
+    Rails.configuration.Languages[locale.to_s].capitalize
   end
 end

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,4 +1,4 @@
 # Whitelist locales available for the application
-I18n.available_locales = %i[en es ja fr]
+I18n.available_locales = %i[en es fr ja]
 
 I18n.default_locale = :en


### PR DESCRIPTION
- `application_helper`: capitalise language name (otherwise `francais` is shown)
- `locale`: reorder languages to look a bit nicer to me