### PR TITLE
Adding Persian to Whitelist locales

### DIFF
--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,4 +1,4 @@
 # Whitelist locales available for the application
-I18n.available_locales = %i[en es fr pt ja zh ko ru uk]
+I18n.available_locales = %i[en es fr pt ja zh ko ru uk fa]
 
 I18n.default_locale = :en

--- a/config/languages.yml
+++ b/config/languages.yml
@@ -45,9 +45,9 @@ default: &default
   et: Eesti
   eu: Euskara
   fa: فارسی
-  fj: Na Vosa Vakaviti
   ff: Fulfulde
   fi: Suomi
+  fj: Na Vosa Vakaviti
   fo: Føroyskt
   fr: français
   fy: Frysk

--- a/config/languages.yml
+++ b/config/languages.yml
@@ -44,7 +44,7 @@ default: &default
   es: Español
   et: Eesti
   eu: Euskara
-  fa: Persian (فارسی)
+  fa: فارسی
   fj: Na Vosa Vakaviti
   ff: Fulfulde
   fi: Suomi

--- a/config/languages.yml
+++ b/config/languages.yml
@@ -44,9 +44,10 @@ default: &default
   es: Español
   et: Eesti
   eu: Euskara
+  fa: Persian (فارسی)
+  fj: Na Vosa Vakaviti
   ff: Fulfulde
   fi: Suomi
-  fj: Na Vosa Vakaviti
   fo: Føroyskt
   fr: français
   fy: Frysk


### PR DESCRIPTION
Hello,

Where we can watch alpha version?
https://opensourcefriday.com/?locale=fa

Target: https://github.com/github/opensourcefriday/pull/571
- Adding to available locales
- Adding to languages.yml -  `fa: Persian (فارسی)`

Best,
Max Base
Open Source Maintainer on GitHub

