### PR TITLE
workflows/tests: start postgres service.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,7 @@ jobs:
     - name: Set up PostgreSQL
       run: |
         sudo apt-get install postgresql libpq-dev
+        sudo service postgresql start
         sudo -u postgres createuser --superuser "$USER"
 
     - name: Bootstrap


### PR DESCRIPTION
It was previously not installed and was started by default on installation. This should handle the both the case where it's installed already and when it's newly installed.