### PR TITLE
Ensure the correct Ruby version is in Gemfile.lock

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,9 @@ jobs:
       with:
         ruby-version: "${{ steps.ruby_version.outputs.RUBY_VERSION }}"
 
+    - name: Check for correct Ruby version in Gemfile.lock
+      run: git grep -o "   ruby ${{ steps.ruby_version.outputs.RUBY_VERSION }}" HEAD -- Gemfile.lock
+
     - name: Get NodeJS version
       run: echo "::set-output name=NODE_VERSION::$(cat .node-version)"
       id: node_version

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,7 +301,7 @@ DEPENDENCIES
   web-console
 
 RUBY VERSION
-   ruby 2.7.0p0
+   ruby 2.7.1p83
 
 BUNDLED WITH
    2.1.2


### PR DESCRIPTION
If this isn't set properly it will break Heroku deploys.