### PR TITLE
Solve problem: set current language into html tag

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="<%= I18n.locale %>">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width">


### PR DESCRIPTION
Hi,

Determining the language of a page can be effective in **SEO** in search results.

So I think we need to make that change.

### ES
http://127.0.0.1:3000/?locale=es
```
<!DOCTYPE html>
<html lang="es">
```

### EN
http://127.0.0.1:3000/?locale=en

```
<!DOCTYPE html>
<html lang="en">
```

### PT
http://127.0.0.1:3000/?locale=pt
```
<!DOCTYPE html>
<html lang="pt">
```

### FA
http://127.0.0.1:3000/?locale=fa
```
<!DOCTYPE html>
<html lang="fa">
```

etc...

Reference:
https://www.w3.org/International/questions/qa-html-language-declarations

If I made a mistake, help me.

Regards,
Max