### PR TITLE
Cleanup Devise usage

### DIFF
--- a/app/views/home/businesses.html.erb
+++ b/app/views/home/businesses.html.erb
@@ -11,7 +11,7 @@
         <h1 class="alt-h1 mb-2"><%= yield :title %></h1>
         <p class="alt-lead text-gray mb-md-5"><%= nbsp_last_word(yield(:description)) %></p>
         <% unless current_user %>
-          <%= button_to user_github_omniauth_authorize_path, class: "btn btn-large btn-primary", role: "button" do %>
+          <%= link_to user_github_omniauth_authorize_path, class: "btn btn-large btn-primary", role: "button", method: :post do %>
             <% t("Sign up with GitHub") %>
           <% end %>
         <% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -7,7 +7,7 @@
     <h1 class="alt-h0 mb-2"><%= yield :title %></h1>
     <p class="alt-lead text-gray mb-md-5 col-md-8 mx-auto"><%= nbsp_last_word(yield(:description)) %></p>
     <% unless current_user %>
-      <%= button_to user_github_omniauth_authorize_path, class: "btn btn-large btn-primary mb-md-4", role: "button", method: :post do %>
+      <%= link_to user_github_omniauth_authorize_path, class: "btn btn-large btn-primary mb-md-4", role: "button", method: :post do %>
         <% t("Sign up with GitHub") %>
       <% end %>
     <% end %>

--- a/app/views/home/maintainers.html.erb
+++ b/app/views/home/maintainers.html.erb
@@ -11,7 +11,7 @@
         <h1 class="alt-h1 mb-2"><%= nbsp_last_word(yield(:title)) %></h1>
         <p class="alt-lead text-gray mb-md-5"><%= nbsp_last_word(yield(:description)) %></p>
         <% unless current_user %>
-          <%= button_to user_github_omniauth_authorize_path, class: "btn btn-large btn-primary", role: "button", method: :post do %>
+          <%= link_to user_github_omniauth_authorize_path, class: "btn btn-large btn-primary", role: "button", method: :post do %>
             <%=t "Sign up with GitHub" %>
           <% end %>
         <% end %>
@@ -92,7 +92,7 @@
 
     <p class="text-gray alt-lead"><%=t "maintainers.visitor.description" %></p>
 
-    <%= button_to user_github_omniauth_authorize_path, class: "btn btn-large btn-primary mb-4", role: "button" do %>
+    <%= link_to user_github_omniauth_authorize_path, class: "btn btn-large btn-primary mb-4", role: "button", method: :post do %>
       <%=t "Sign up with GitHub" %>
     <% end %>
   </div>

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -16,16 +16,14 @@
   <% if current_user %>
     <span class="f5 mx-6 mr-sm-0 ml-sm-4 mt-3 mt-sm-0 d-block d-sm-inline-block border rounded-1">
 
-    <a class="d-inline-block py-2 px-3 border-right link-gray-dark" href="/users/<%= current_user.github_username %>">
+    <a class="d-inline-block py-2 px-3 link-gray-dark" href="/users/<%= current_user.github_username %>">
       <%= current_user.github_username %>
     </a>
-
-    <%= button_to t("Sign out"), destroy_user_session_path, class: "py-2 px-3" %>
 
     </span>
 
   <% else %>
-    <%= button_to user_github_omniauth_authorize_path, class: "mx-6 mr-sm-0 ml-sm-4 mt-3 mt-sm-0 d-block d-sm-inline-block btn btn-outline" do %>
+    <%= link_to user_github_omniauth_authorize_path, class: "mx-6 mr-sm-0 ml-sm-4 mt-3 mt-sm-0 d-block d-sm-inline-block btn btn-outline", method: :post do %>
       <%=t "Sign up" %>
     <% end %>
   <% end %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -242,7 +242,7 @@ Devise.setup do |config|
   # config.navigational_formats = ['*/*', :html]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
-  config.sign_out_via = :get
+  config.sign_out_via = :delete
 
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting


### PR DESCRIPTION
- Use `link_to` with `method: :post` instead of `button_to` for links
- Remove sign out (it seems to be broken entirely)