### PR TITLE
build(deps): bump rails from 6.0.3.4 to 6.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ ruby IO.read(File.expand_path("#{File.dirname(__FILE__)}/.ruby-version")).strip
 
 gem "devise"
 gem "devise-i18n"
-gem "failbot_rails"
 gem "faraday-http-cache"
 gem "figaro"
 gem "jquery-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,10 +79,6 @@ GEM
     docile (1.3.4)
     erubi (1.10.0)
     execjs (2.7.0)
-    failbot (2.5.5)
-    failbot_rails (0.5.0)
-      failbot (>= 0.9.2, < 3)
-      rails (>= 4)
     faraday (1.2.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
@@ -278,7 +274,6 @@ DEPENDENCIES
   dalli
   devise
   devise-i18n
-  failbot_rails
   faraday-http-cache
   figaro
   heroku-deflater

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,10 +2,6 @@ require_relative "boot"
 
 require "rails/all"
 
-ENV["FAILBOT_BACKEND"] ||= "memory"
-require "failbot_rails"
-FailbotRails.setup("opensourcefriday")
-
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,8 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
   # Set cache headers for static assets
   config.public_file_server.headers = {
     "Cache-Control" => "public, max-age=31536000",
-    "Expires" => 6.months.from_now.to_formatted_s(:rfc822),
+    # 6 months from now
+    "Expires" => (Date.today + 180).to_datetime.to_formatted_s(:rfc822),
   }
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb


### PR DESCRIPTION
Take-two of https://github.com/github/opensourcefriday/pull/825
Reverts github/opensourcefriday#829

Shortly: will include https://github.com/github/opensourcefriday/pull/828.

I think this will require Heroku configuration changes to work properly. 

This PR should be deployed successfully before merge. Ideally, we enable Heroku Review Apps for this repository before merge.