### PR TITLE
Gemfile: remove awesome_print

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ group :development, :test do
 end
 
 group :development do
-  gem "awesome_print"
   gem "listen"
   gem "rubocop"
   gem "spring"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,6 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
-    awesome_print (1.9.2)
     bcrypt (3.1.16)
     bindex (0.8.1)
     builder (3.2.4)
@@ -275,7 +274,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  awesome_print
   byebug
   connection_pool
   dalli


### PR DESCRIPTION
It's no longer needed/used (I added it for my use and don't use it any more, `pp` for life).