### PR TITLE
Migrate from "actions/setup-ruby@v1"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       id: ruby_version
 
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: "${{ steps.ruby_version.outputs.RUBY_VERSION }}"
 


### PR DESCRIPTION
Here is a screen of a falling build caused by the current action:
<img width="644" alt="CleanShot 2021-04-19 at 18 02 05@2x" src="https://user-images.githubusercontent.com/343914/115308832-5cf99380-a139-11eb-8fc1-ce3ebfe6dbcf.png">

The solution is to migrate to https://github.com/ruby/setup-ruby, which is being actively maintained. This is currently blocking the ability to merge the current active PRs