### PR TITLE
github/workflows/tests: migrate to maintained setup-ruby.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,57 +7,57 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Git repository
-      uses: actions/checkout@v1
+      - name: Set up Git repository
+        uses: actions/checkout@v1
 
-    - name: Get Ruby version
-      run: echo "::set-output name=RUBY_VERSION::$(cat .ruby-version)"
-      id: ruby_version
+      - name: Get Ruby version
+        run: echo "::set-output name=RUBY_VERSION::$(cat .ruby-version)"
+        id: ruby_version
 
-    - name: Set up Ruby
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: "${{ steps.ruby_version.outputs.RUBY_VERSION }}"
+      - name: Set up Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: "${{ steps.ruby_version.outputs.RUBY_VERSION }}"
 
-    - name: Check for correct Ruby version in Gemfile.lock
-      run: git grep -o "   ruby ${{ steps.ruby_version.outputs.RUBY_VERSION }}" HEAD -- Gemfile.lock
+      - name: Check for correct Ruby version in Gemfile.lock
+        run: git grep -o "   ruby ${{ steps.ruby_version.outputs.RUBY_VERSION }}" HEAD -- Gemfile.lock
 
-    - name: Get NodeJS version
-      run: echo "::set-output name=NODE_VERSION::$(cat .node-version)"
-      id: node_version
+      - name: Get NodeJS version
+        run: echo "::set-output name=NODE_VERSION::$(cat .node-version)"
+        id: node_version
 
-    - name: Set up NodeJS
-      uses: actions/setup-node@v1
-      with:
-        node-version: "${{ steps.node_version.outputs.NODE_VERSION }}"
+      - name: Set up NodeJS
+        uses: actions/setup-node@v1
+        with:
+          node-version: "${{ steps.node_version.outputs.NODE_VERSION }}"
 
-    - name: Set up PostgreSQL
-      run: |
-        sudo apt-get install postgresql libpq-dev
-        sudo service postgresql start
-        sudo -u postgres createuser --superuser "$USER"
+      - name: Set up PostgreSQL
+        run: |
+          sudo apt-get install postgresql libpq-dev
+          sudo service postgresql start
+          sudo -u postgres createuser --superuser "$USER"
 
-    - name: Bootstrap
-      run: script/bootstrap
+      - name: Bootstrap
+        run: script/bootstrap
 
-    - name: Check for uncommitted NodeJS modules
-      run: |
-        git diff --stat --exit-code node_modules || {
-          echo '\n\nError: you must commit all NodeJS modules!'
-          exit 1
-        }
-        grep -qr alt-h0 node_modules || {
-          echo 'Error: Primer NodeJS modules must contain alt-h0!'
-          exit 1
-        }
+      - name: Check for uncommitted NodeJS modules
+        run: |
+          git diff --stat --exit-code node_modules || {
+            echo '\n\nError: you must commit all NodeJS modules!'
+            exit 1
+          }
+          grep -qr alt-h0 node_modules || {
+            echo 'Error: Primer NodeJS modules must contain alt-h0!'
+            exit 1
+          }
 
-    - name: Set up Rails
-      run: script/setup
-      env:
-        RAILS_ENV: test
+      - name: Set up Rails
+        run: script/setup
+        env:
+          RAILS_ENV: test
 
-    - name: Run tests
-      run: bundle exec rake test
+      - name: Run tests
+        run: bundle exec rake test
 
-    - name: Run RuboCop
-      run: bundle exec rubocop
+      - name: Run RuboCop
+        run: bundle exec rubocop

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
         id: ruby_version
 
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: "${{ steps.ruby_version.outputs.RUBY_VERSION }}"
 


### PR DESCRIPTION
The previous version was deprecated.

As mentioned in https://github.com/github/opensourcefriday/pull/943#issuecomment-821199019

While we're here: autoformat the YAML, too.