### PR TITLE
Remove: "Your first pull request" website link

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -30,7 +30,7 @@
         <h3 class="alt-h3 mb-2"><%=t "index.main.contribution" %></h3>
 
         <p class="text-gray f4 mb-3">
-        <%=t "headline.contributors" %>
+          <%=t "headline.contributors" %>
         </p>
 
         <p>
@@ -49,7 +49,7 @@
       <div class="col-md-4 mb-6">
         <h4 class="mb-2"><%=t "index.find.used.title" %></h4>
         <p class="text-gray">
-            <%=t "index.find.used.description" %>
+          <%=t "index.find.used.description" %>
         </p>
       </div>
       <div class="col-md-4 mb-6">
@@ -58,7 +58,6 @@
         <p class="text-gray"><%=t "index.find.issue.description" %></p>
 
         <ul class="ml-3">
-          <li><a href="https://yourfirstpr.github.io/"><%=t "index.find.issue.first" %></a></li>
           <li><a href="http://up-for-grabs.net/"><%=t "index.find.issue.grabs" %></a></li>
           <li><a href="https://www.codetriage.com/"><%=t "index.find.issue.triage" %></a></li>
         </ul>


### PR DESCRIPTION
Hi

It was worth asking questions because James did a decent job of helping open source software.

I already ask about this issue from James(@varjmes), but he not replied. so I think we are allowed to remove "Your First PR".
As Mike (@MikeMcQuaid) agreed with it.

Related issue: https://github.com/github/opensourcefriday/issues/1103

P.S: I not removed "index.find.issue.first" field from language files, since I guess maybe we need "Your first Pull request" word in somewhere. (It already translated into a couple of languages)

Best,
Max