### PR TITLE
Rescue and handle Octokit::Unauthorized when viewing user pages

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -36,6 +36,10 @@ class UsersController < ApplicationController
   rescue Octokit::NotFound
     flash[:error] = "GitHub user @#{params[:id]} not found!"
     redirect_to root_path
+  rescue Octokit::Unauthorized
+    sign_out(current_user)
+    flash[:error] = t(".token_unauthorized")
+    redirect_to root_path
   end
 
   private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,6 +165,7 @@ en:
     share_activity:
       description_html: 'Share your Open Source Friday contributions with others <a href="%{url}">using this URL</a>.'
       message_html: "Check out my contributions to open source on #OpenSourceFriday: %{url}"
+    token_unauthorized: "Your GitHub OAuth Token is invalid.  Please sign in again."
 
   # app/views/layouts/_calendar.erb
   calendar:

--- a/test/vcr_cassettes/user_invalid.yml
+++ b/test/vcr_cassettes/user_invalid.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/users/MikeMcQuaid
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 4.7.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      server:
+      - GitHub.com
+      date:
+      - Mon, 29 May 2017 14:09:06 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 401 Unauthorized
+      x-ratelimit-limit:
+      - '5000'
+      x-ratelimit-remaining:
+      - '4991'
+      x-ratelimit-reset:
+      - '1496070428'
+      cache-control:
+      - private, max-age=60, s-maxage=60
+      vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding
+      etag:
+      - W/"2eaf444613f95b4a8a30c2c83aa36582"
+      last-modified:
+      - Fri, 12 May 2017 16:13:45 GMT
+      x-github-media-type:
+      - github.v3; format=json
+      access-control-expose-headers:
+      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      access-control-allow-origin:
+      - "*"
+      content-security-policy:
+      - default-src 'none'
+      strict-transport-security:
+      - max-age=31536000; includeSubdomains; preload
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - deny
+      x-xss-protection:
+      - 1; mode=block
+      x-served-by:
+      - 3e3b9690823fb031da84658eb58aa83b
+      x-github-request-id:
+      - 8E55:2E0FD:401E260:4D515D5:592C2B82
+      body:
+        encoding: "UTF-8"
+        base64_string: "eyJtZXNzYWdlIjoiQmFkIGNyZWRlbnRpYWxzIiwiZG9jdW1lbnRhdGlvbl91\ncmwiOiJodHRwczovL2RldmVsb3Blci5naXRodWIuY29tL3YzIn0=\n"
+    http_version: 
+  recorded_at: Mon, 29 May 2017 14:09:06 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
It's possible for a user's OAuth token to get invalidated by whoever manages the connected OpenSourceFriday OAuth app on GitHub.  With the current behavior, the user will be shown a 500 error page which doesn't describe what went wrong or how to fix it.

Fixing the problem is pretty straightforward though, the user needs to sign out and sign back in to go through the OAuth flow again and generate a new token.  To give a better overall experience, I've updated the `UsersController#show` action to catch the error when it occurs and then
- sign the user out
- redirect them to the homepage
- prompt them to sign in again with a flash error message

I reproduced the issue when running the app locally per the README instructions (🙇   very helpful!) and with the change in this PR the user will end up seeing the following after being redirected:

![Screen Shot 2022-04-20 at 5 50 40 PM](https://user-images.githubusercontent.com/5263772/164350031-cf58f59f-a936-436a-a6a6-d9ea932970ee.png)

I added the token to the english localization file but I don't speak the other languages to supply non-english translations.