### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
         uses: ruby/setup-ruby@v1
 
       - name: Get NodeJS version
-        run: echo "::set-output name=NODE_VERSION::$(cat .node-version)"
+        run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_OUTPUT
         id: node_version
 
       - name: Set up NodeJS


### PR DESCRIPTION
`save-state` and `set-output` commands [used in GitHub Actions are deprecated](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


