### PR TITLE
Spanish spelling corrections

### DIFF
--- a/_data/locales/es.yml
+++ b/_data/locales/es.yml
@@ -97,7 +97,7 @@ es:
       name: "Kim Crayton"
       message: "Contribuir al código abierto no solo permite a las empresas de todos los tamaños aprovechar y aprovechar los talentos de los demás, sino que también es una forma de que los nuevos en codificación se aclimaten al proceso de desarrollo de forma que les permita practicar, experimentar y exhibir. ellos mismos como miembros valiosos y contribuyentes de la comunidad."
     Chris_Lamb:
-      title: "<a href='https://www.debian.org'>Debian Project</a> Lider"
+      title: "<a href='https://www.debian.org'>Debian Project</a> Líder"
       name: "Chris Lamb"
       message: "Llegué a donde estoy hoy contribuyendo al software de código abierto, lo que me permite no solo mejorar mis habilidades como desarrollador de software sino también aumentar mi red de colegas y conocer nuevos e interesantes amigos de culturas extremadamente diversas. Lo puedo recomendar."
     Will_Norris:

--- a/_data/locales/es.yml
+++ b/_data/locales/es.yml
@@ -83,7 +83,7 @@ es:
       description: "Aprende de otros mantenedores la forma de ser más efectivo."
       boundaries:
         title: "Establece límites"
-        description: 'Decide cual es el alcance del proyecto e <a href="https://opensource.guide/es/best-practices/#está-bien-poner-pausa">imponete límites claros para vos mismo</a>. Decir no <a href="https://opensource.guide/es/best-practices/#aprendiendo-a-decir-no"> es tan importante como decir sí</a>.'
+        description: 'Decide cual es el alcance del proyecto e <a href="https://opensource.guide/es/best-practices/#está-bien-poner-pausa">imponente límites claros para vos mismo</a>. Decir no <a href="https://opensource.guide/es/best-practices/#aprendiendo-a-decir-no"> es tan importante como decir sí</a>.'
       automation:
         title: "Automatización"
         description: '<a href="https://opensource.guide/es/best-practices/#traigan-a-los-robots">Traigan a los robots</a> para automatizar tanto como sea posible las pruebas y otras verificaciones para ahorrarle tiempo.'


### PR DESCRIPTION
- [x] Have you followed the [contributing guidelines](https://github.com/github/opensourcefriday/blob/HEAD/CONTRIBUTING.md)? -- they aren't really applicable, and this repository doesn't actually support issues.
- [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----

- `imponete` is a typo for `imponente`
   https://translate.google.com/details?sl=es&tl=en&text=Decide%20cual%20es%20el%20alcance%20del%20proyecto%20e%20imponete%20l%C3%ADmites%20claros%20para%20vos%20mismo&op=translate
   > Did you mean: Decide cual es el alcance del proyecto e **_imponente_** límites claros para vos mismo
- `Lider` is a typo for `Líder`.
  https://es.wikipedia.org/wiki/Categor%C3%ADa:L%C3%ADderes_del_Proyecto_Debian
   https://es.wikipedia.org/wiki/Ian_Jackson
   > Cargos ocupados: Líder del proyecto Debian

Reported by check-spelling in https://github.com/check-spelling-sandbox/opensourcefriday/actions/runs/26723346400#summary-78754262966 using 
https://github.com/check-spelling/cspell-dicts/blob/v20230509/dictionaries/es_ES/src/hunspell/index.dic
https://github.com/check-spelling/cspell-dicts/blob/v20230509/dictionaries/es_ES/src/hunspell/index.aff

---

Admittedly, I'm not a native Spanish speaker (I studied Spanish in High School decades ago...), but ...