### PR TITLE
Spanish spelling corrections (re-opened from #1331)

### DIFF
--- a/_data/locales/es.yml
+++ b/_data/locales/es.yml
@@ -97,7 +97,7 @@ es:
       name: "Kim Crayton"
       message: "Contribuir al código abierto no solo permite a las empresas de todos los tamaños aprovechar y aprovechar los talentos de los demás, sino que también es una forma de que los nuevos en codificación se aclimaten al proceso de desarrollo de forma que les permita practicar, experimentar y exhibir. ellos mismos como miembros valiosos y contribuyentes de la comunidad."
     Chris_Lamb:
-      title: "<a href='https://www.debian.org'>Debian Project</a> Lider"
+      title: "<a href='https://www.debian.org'>Debian Project</a> Líder"
       name: "Chris Lamb"
       message: "Llegué a donde estoy hoy contribuyendo al software de código abierto, lo que me permite no solo mejorar mis habilidades como desarrollador de software sino también aumentar mi red de colegas y conocer nuevos e interesantes amigos de culturas extremadamente diversas. Lo puedo recomendar."
     Will_Norris:

--- a/_data/locales/es.yml
+++ b/_data/locales/es.yml
@@ -83,7 +83,7 @@ es:
       description: "Aprende de otros mantenedores la forma de ser más efectivo."
       boundaries:
         title: "Establece límites"
-        description: 'Decide cual es el alcance del proyecto e <a href="https://opensource.guide/es/best-practices/#está-bien-poner-pausa">imponete límites claros para vos mismo</a>. Decir no <a href="https://opensource.guide/es/best-practices/#aprendiendo-a-decir-no"> es tan importante como decir sí</a>.'
+        description: 'Decide cual es el alcance del proyecto e <a href="https://opensource.guide/es/best-practices/#está-bien-poner-pausa">imponente límites claros para vos mismo</a>. Decir no <a href="https://opensource.guide/es/best-practices/#aprendiendo-a-decir-no"> es tan importante como decir sí</a>.'
       automation:
         title: "Automatización"
         description: '<a href="https://opensource.guide/es/best-practices/#traigan-a-los-robots">Traigan a los robots</a> para automatizar tanto como sea posible las pruebas y otras verificaciones para ahorrarle tiempo.'

--- a/_data/locales/es.yml
+++ b/_data/locales/es.yml
@@ -83,7 +83,7 @@ es:
       description: "Aprende de otros mantenedores la forma de ser más efectivo."
       boundaries:
         title: "Establece límites"
-        description: 'Decide cual es el alcance del proyecto e <a href="https://opensource.guide/es/best-practices/#está-bien-poner-pausa">imponente límites claros para vos mismo</a>. Decir no <a href="https://opensource.guide/es/best-practices/#aprendiendo-a-decir-no"> es tan importante como decir sí</a>.'
+        description: 'Decide cual es el alcance del proyecto e <a href="https://opensource.guide/es/best-practices/#está-bien-poner-pausa">imponete límites claros para vos mismo</a>. Decir no <a href="https://opensource.guide/es/best-practices/#aprendiendo-a-decir-no"> es tan importante como decir sí</a>.'
       automation:
         title: "Automatización"
         description: '<a href="https://opensource.guide/es/best-practices/#traigan-a-los-robots">Traigan a los robots</a> para automatizar tanto como sea posible las pruebas y otras verificaciones para ahorrarle tiempo.'


### PR DESCRIPTION
Re-opens the spelling fixes from #1331 from a local branch so CodeQL runs and the org code-scanning ruleset can be satisfied (fork PRs don't get CodeQL coverage in this repo, leaving #1331 permanently BLOCKED even with green tests).

Originally cherry-picked both of @jsoref's commits. After Copilot review I reverted one:

✅ Lider → Líder — kept (missing accent)
⛔ imponete → imponente — reverted. imponete is the voseo imperative of imponer + reflexive te (paired with vos mismo on the next line), not a typo for imponte. imponente is an unrelated adjective ("imposing"), so the swap would have changed the meaning.
Net change: one accent on Líder.

Closes #1331.