### PR TITLE
Move external link checks to a weekly scheduled run

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,31 @@
+name: Weekly External Link Check
+on:
+  schedule:
+    # Every Monday at 08:00 UTC
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v7
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74
+      - name: Get NodeJS version
+        run: echo "NODE_VERSION=$(cat .node-version)" >> $GITHUB_OUTPUT
+        id: node_version
+      - name: Set up NodeJS
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: "${{ steps.node_version.outputs.NODE_VERSION }}"
+      - name: Bootstrap
+        run: script/bootstrap
+      - name: Build site
+        run: script/build
+      - name: Check links (including external URLs)
+        run: bundle exec script/html-proofer
+        env:
+          CHECK_EXTERNAL_LINKS: true

--- a/script/html-proofer
+++ b/script/html-proofer
@@ -1,12 +1,26 @@
 #!/usr/bin/env ruby
 require "html-proofer"
 
+# External (remote) link checking is opt-in.
+# Set CHECK_EXTERNAL_LINKS=true to enable (used by weekly scheduled run).
+check_external = %w[1 true yes].include?(
+  ENV.fetch("CHECK_EXTERNAL_LINKS", "").strip.downcase
+)
+
+if check_external
+  puts "==> Running HTMLProofer WITH external link checks"
+else
+  puts "==> Running HTMLProofer WITHOUT external link checks " \
+       "(set CHECK_EXTERNAL_LINKS=true to enable)"
+end
+
 url_ignores = [
   "http://comcast.com",
 ]
 
 HTMLProofer.check_directories(
   ["_site"],
+  disable_external: !check_external,
   enforce_https: false,
   ignore_status_codes: [429],
   ignore_urls: url_ignores,

--- a/script/test
+++ b/script/test
@@ -3,4 +3,8 @@
 set -e
 
 script/build
-bundle exec script/html-proofer
+
+# Skip external URL checks in normal CI. They are slow and frequently fail
+# due to rate limiting on third-party sites. The full external link check
+# runs on a weekly schedule (see .github/workflows/link-check.yml).
+CHECK_EXTERNAL_LINKS=false bundle exec script/html-proofer


### PR DESCRIPTION
External URL checks are slow and frequently fail in CI due to rate limiting and transient network errors on third-party sites, which can block otherwise valid contributions.

This mirrors the approach taken in [github/opensource.guide#3703](https://github.com/github/opensource.guide/pull/3703).

### Changes

- **`script/html-proofer`** — External link checking is now opt-in via `CHECK_EXTERNAL_LINKS` env var (defaults to off)
- **`script/test`** — Explicitly disables external checks so CI stays fast and reliable
- **`.github/workflows/link-check.yml`** — New weekly scheduled workflow (Mondays 08:00 UTC) that runs the full external link check, with `workflow_dispatch` for manual triggers